### PR TITLE
replace jax.experimental.optix by optimisers && migrate to FLAX model

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -6,8 +6,8 @@ import flax.linen as nn
 class Model(nn.Module):   
     width = 256
     depth = 6
-    use_viewdirs = False
 
+    @nn.compact
     def __call__(self, coords):
         sh = coords.shape
         coords = np.reshape(coords, [-1 ,3])

--- a/src/models.py
+++ b/src/models.py
@@ -1,14 +1,12 @@
 import jax
-import haiku as hk
 import jax.numpy as np
+import flax.linen as nn
 
 
-class Model(hk.Module):
-    def __init__(self):
-        super().__init__()
-        self.width = 256
-        self.depth = 6
-        self.use_viewdirs = False
+class Model(nn.Module):   
+    width = 256
+    depth = 6
+    use_viewdirs = False
 
     def __call__(self, coords):
         sh = coords.shape
@@ -19,10 +17,10 @@ class Model(hk.Module):
             np.sin(coords*(2**i)), np.cos(coords*(2**i))
         ], axis=-1) for i in np.linspace(0, 8, 20)], axis=-1)
 
-        for _ in range(self.depth-1):
-            x = hk.Linear(output_size=self.width)(x)
-            x = jax.nn.relu(x)
+        for idx in range(self.depth - 1):
+            x = nn.Dense(output_size=self.width, name=f"fc{idx}")(x)
+            x = nn.relu(x)
 
-        out = hk.Linear(output_size=4)(x)
+        out = nn.Dense(output_size=4, name="fc_last")(x)
         out = np.reshape(out, list(sh[:-1]) + [4])
         return out

--- a/src/step_utils.py
+++ b/src/step_utils.py
@@ -14,9 +14,11 @@ inner_update_steps = 64
 N_samples = 128
 test_inner_steps = 64
 
-rng = jax.random.PRNGKey(0)
-model = hk.without_apply_rng(hk.transform(lambda x: Model()(x)))
-params = model.init(rng, np.ones((1,3)))
+model = Model()
+key1, key2 = random.split(jax.random.PRNGKey(0))
+dummy_x = random.normal(key1, (1, 3))
+params = model.init(key2, dummy_x)
+
 opt_init, opt_update, get_params = optimizers.adam(lr)
 opt_state = opt_init(params)
 

--- a/src/step_utils.py
+++ b/src/step_utils.py
@@ -1,7 +1,7 @@
 import jax
 import jax.numpy as np
 from jax import jit, random
-from jax.experimental import optix
+from jax.experimental import optimizers
 import haiku as hk
 
 from models import Model
@@ -17,8 +17,8 @@ test_inner_steps = 64
 rng = jax.random.PRNGKey(0)
 model = hk.without_apply_rng(hk.transform(lambda x: Model()(x)))
 params = model.init(rng, np.ones((1,3)))
-opt = optix.adam(lr)
-opt_state = opt.init(params)
+opt_init, opt_update, get_params = optimizers.adam(lr)
+opt_state = opt_init(params)
 
 
 def render_fn(rnd_input, model, params, bvals, rays, near, far, N_samples, rand):
@@ -103,35 +103,32 @@ def update_network_weights(rng, images, rays, params, inner_steps, bds):
         idx = random.randint(rng_input, shape=(batch_size,), minval=0, maxval=images.shape[0])
         image_sub = images[idx, :]
         rays_sub = rays[:, idx, :]
-
         rng, params, loss = single_step(rng, image_sub, rays_sub, params, bds)
     return rng, params, loss
 
 
-def update_model(rng, params, opt_state, image, rays, bds):
+def update_model(step, rng, params, opt_state, image, rays, bds):
     rng, new_params, model_loss = update_network_weights(rng, image, rays, params, inner_update_steps, bds)
 
     def calc_grad(params, new_params):
         return params - new_params
 
     model_grad = jax.tree_multimap(calc_grad, params, new_params)
-
-    updates, opt_state = opt.update(model_grad, opt_state)
-    params = optix.apply_updates(params, updates)
+    opt_state = opt_update(step, model_grad, opt_state)
+    params = get_params(opt_state)
     return rng, params, opt_state, model_loss
 
 
 @jit
-def update_model_single(rng, params, opt_state, image, rays, bds):
-    rng, new_params, model_loss = single_step(rng, image, rays, params, bds)
+def update_model_single(step, rng, params, opt_state, image, rays, bds):
 
     def calc_grad(params, new_params):
         return params - new_params
 
+    rng, new_params, model_loss = single_step(rng, image, rays, params, bds)
     model_grad = jax.tree_multimap(calc_grad, params, new_params)
-
-    updates, opt_state = opt.update(model_grad, opt_state)
-    params = optix.apply_updates(params, updates)
+    opt_state = opt_update(step, model_grad, opt_state)
+    params = get_params(opt_state)
     return rng, params, opt_state, model_loss
 
 

--- a/src/train_loop.py
+++ b/src/train_loop.py
@@ -1,5 +1,3 @@
-import os
-import glob
 import pickle
 
 import imageio
@@ -10,7 +8,7 @@ from livelossplot import PlotLosses
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 
-from step_utils import (update_network_weights, inner_update_steps, batch_size,
+from step_utils import (update_network_weights, inner_update_steps,
                         update_model_single, update_model, N_samples,
                         test_inner_steps, render_fn, psnr_fn,
                         batch_size, model, params, opt_state, inner_step_size, lr)
@@ -21,7 +19,7 @@ max_iters = 150000
 exp_name = f'{DATASET}_ius_{inner_update_steps}_ilr_{inner_step_size}_olr_{lr}_bs_{batch_size}'
 exp_dir = f'checkpoint/phototourism_checkpoints/{exp_name}/'
 
-plt_groups = {'Train PSNR':[], 'Test PSNR':[]}
+plt_groups = {'Train PSNR': [], 'Test PSNR': []}
 plotlosses_model = PlotLosses(groups=plt_groups)
 plt_groups['Train PSNR'].append(exp_name + f'_train')
 plt_groups['Test PSNR'].append(exp_name + f'_test')
@@ -49,9 +47,11 @@ for step in tqdm(range(max_iters)):
     if inner_update_steps == 1:
         rng, rng_input = random.split(rng)
         idx = random.randint(rng_input, shape=(batch_size,), minval=0, maxval=images.shape[0])
-        rng, params, opt_state, loss = update_model_single(rng, params, opt_state, images[idx, :], rays[:, idx, :], bds)
+        rng, params, opt_state, loss = update_model_single(step, rng, params, opt_state,
+                                                           images[idx, :], rays[:, idx, :], bds)
     else:
-        rng, params, opt_state, loss = update_model(rng, params, opt_state, images, rays, bds)
+        rng, params, opt_state, loss = update_model(step, rng, params, opt_state,
+                                                    images, rays, bds)
     train_psnrs.append(-10 * np.log10(loss))
 
     if step % 250 == 0:


### PR DESCRIPTION
**Changes**
1. `jax.experimental.optix` is deprecated in latest JAX version, use `optimisers` instead. Unlike optimizers in `optix`, the optimizers in `optimisers` requires additional arg `step` (`int`) in order to get additional state (e.g. momentum, velocity, annealing learning rate ...etc)
2. migrating (simplified) NeRF from Haiku framework to FLAX

**Remarks**
We do noticed there are other FLAX/ JAX based implementation, but we decided not to port them into our codebase at the moment, because their model implementation is way more complex and their interface (e.g. expected input) is quite different from what we have. Also our implementation is a simplified one (refer to https://github.com/tancik/learnit/issues/9), so porting other implementation will introduce additional change (and complexity). We can add them in when we have additional bandwidth, but I dont think it should be a priority rn